### PR TITLE
Cancel dialog if user pressed the Cancel button or the X button.

### DIFF
--- a/PrepPipeline/pop_prepPipeline.m
+++ b/PrepPipeline/pop_prepPipeline.m
@@ -53,6 +53,12 @@ if nargin < 2
     userData = getUserData();
     [params, okay] = MasterGUI([],[],userData, EEG);
 end
+
+%% return if user pressed cancel
+if (~okay) 
+	return;
+end
+
 userData = getUserData();
 com = sprintf('pop_prepPipeline(%s, %s);', inputname(1), ...
     struct2str(params));


### PR DESCRIPTION
Simple fix for having the Cancel button do nothing instead of opening the save dialog.

If accepted you could also change the documentation that led me to propose this fix:
Each button allows you to override the default parameters. When you press the Ok button (or unfortunately the Cancel button), PREP runs. Use the x button on the upper right to quit without running the pipeline.
