### PR TITLE
Avoid parfor error for non-consecutive channels

### DIFF
--- a/PrepPipeline/utilities/cleanLineNoise.m
+++ b/PrepPipeline/utilities/cleanLineNoise.m
@@ -52,11 +52,10 @@ Nwin = round(lineNoiseOut.Fs*lineNoiseOut.taperWindowSize); % number of samples 
 lineNoiseOut.tapers = checkTapers(lineNoiseOut.taperTemplate, Nwin, lineNoiseOut.Fs); 
 
 %% Perform the calculation for each channel separately
-data = double(signal.data);
-chans = sort(lineNoiseOut.lineNoiseChannels);
-parfor ch = chans
+calcChans = lineNoiseOut.lineNoiseChannels;
+data = double(signal.data(calcChans, :));
+parfor ch = 1:size(data, 1)
     data(ch, :) = removeLinesMovingWindow(squeeze(data(ch, :)), lineNoiseOut);
 end
-signal.data = data;
+signal.data(calCchans, :) = data;
 clear data;
-


### PR DESCRIPTION
Minimal non-working example:

```
[EEG,conf,times] = prepPipeline(EEG, struct('lineNoiseChannels', [1,3]));
```

```
> In prepPipeline (line 49)
  In eegpreproc/prep (line 189) 
Checking for boundary events
Preliminary detrend to compute reference
pop_eegfiltnew() - performing 827 point highpass filtering.
pop_eegfiltnew() - transition band width: 1 Hz
pop_eegfiltnew() - passband edge(s): 1 Hz
pop_eegfiltnew() - cutoff frequency(ies) (-6 dB): 0.5 Hz
pop_eegfiltnew() - filtering the data (zero-phase, non-causal)
firfilt(): |====================| 100%, ETE 00:00
Line noise removal
Warning: [MATLAB:parfor:range_not_consecutive]
Error using parfor_range_check (line 63)
The range of the parfor-loop variable must evaluate to a row vector of consecutive
increasing integers. For more information see parfor-Loops in MATLAB, "parfor".

Error in cleanLineNoise (line 57)
parfor ch = chans

Error in removeLineNoise (line 67)
    [signal, lineNoiseOut] = cleanLineNoise(signal, lineNoiseOut);

Error in prepPipeline (line 137)
        [EEGClean, lineNoise] = removeLineNoise(EEGNew, params);
```

